### PR TITLE
cmake: switch from using deprecated linklibraries to target_linklibraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,10 +98,6 @@ include_directories(
   ${Boost_INCLUDE_DIRS} 
   )
 
-# link against boost and python libraries
-LINK_LIBRARIES(${Boost_LIBRARIES}) # Deprecated but so convenient!
-LINK_LIBRARIES(${PYTHON_LIBRARY})
-
 # install headers
 install(DIRECTORY boost
     DESTINATION "include"

--- a/libs/numpy/example/CMakeLists.txt
+++ b/libs/numpy/example/CMakeLists.txt
@@ -3,7 +3,7 @@ macro( addPythonExe _name _srccpp )
   ADD_EXECUTABLE(${_name} ${_srccpp})
   
   # make the pyd library link against boost_numpy python and boost
-  TARGET_LINK_LIBRARIES(${_name} boost_numpy ${PYTHON_LIBRARIES} ${Boost_LIBRARIES})
+  TARGET_LINK_LIBRARIES(${_name} boost_numpy)
   
   # put the example target into a VS solution folder named example (should
   # be a no-op for Linux)
@@ -14,7 +14,7 @@ macro( addPythonMod _name _srccpp )
   PYTHON_ADD_MODULE(${_name} ${_srccpp})
   
   # make the pyd library link against boost_numpy python and boost
-  TARGET_LINK_LIBRARIES(${_name} boost_numpy ${PYTHON_LIBRARIES} ${Boost_LIBRARIES})
+  TARGET_LINK_LIBRARIES(${_name} boost_numpy)
   
   # put the example target into a VS solution folder named example (should
   # be a no-op for Linux)

--- a/libs/numpy/src/CMakeLists.txt
+++ b/libs/numpy/src/CMakeLists.txt
@@ -17,6 +17,7 @@ add_library(boost_numpy ${LIBRARY_TYPE}
   ufunc.cpp
   numpy.cpp
 )
+target_link_libraries(boost_numpy ${Boost_LIBRARIES} ${PYTHON_LIBRARIES})
 
 install(TARGETS boost_numpy 
   ARCHIVE DESTINATION lib 

--- a/libs/numpy/test/CMakeLists.txt
+++ b/libs/numpy/test/CMakeLists.txt
@@ -17,7 +17,7 @@ set( TestCommand ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${runCmakeTest} )
 # custom macro with most of the redundant code for making a python test
 macro( addPythonTest _name _srcpy )
   # make the pyd library link against boost_numpy python and boost
-  TARGET_LINK_LIBRARIES(${_name} boost_numpy ${PYTHON_LIBRARIES} ${Boost_LIBRARIES})
+  TARGET_LINK_LIBRARIES(${_name} boost_numpy)
   
   # make a test of the module using the python source file in the test directory
   ADD_TEST(${_name} ${TestCommand} ${TEST_SOURCE_DIR}/${_srcpy})


### PR DESCRIPTION
the total information duplication actually decreases and it
facilitates reusing CMake instructions from outer projects.
