### PR TITLE
SCons change to build a static lib for Windows

### DIFF
--- a/libs/numpy/src/SConscript
+++ b/libs/numpy/src/SConscript
@@ -6,9 +6,15 @@
 #          http://www.boost.org/LICENSE_1_0.txt)
 
 import sys
+import os
 VERSION = sys.version_info.major
 import sysconfig
-EXT_SUFFIX = sysconfig.get_config_var("EXT_SUFFIX")
+if os.name == 'nt':
+    EXT_SUFFIX = '.dll'
+    LIB_SUFFIX = '.lib'
+else:
+    EXT_SUFFIX = sysconfig.get_config_var("EXT_SUFFIX")
+    LIB_SUFFIX = EXT_SUFFIX
 
 if VERSION == 2 and EXT_SUFFIX == 'None' or EXT_SUFFIX==None:
 	EXT_SUFFIX = '.so'
@@ -20,10 +26,13 @@ OBJ_SUFFIX = EXT_SUFFIX.replace ('.so', '.os')
 
 Import("env")
 
-LIB_BOOST_NUMPY = ('boost_numpy' + EXT_SUFFIX)
+LIB_BOOST_NUMPY = ('boost_numpy' + LIB_SUFFIX)
 mods = [g.name.replace('.cpp', '') for g in Glob("*.cpp")]
 for m in mods:
     env.SharedObject (target=m+OBJ_SUFFIX, source=m+'.cpp')
-lib = env.SharedLibrary(LIB_BOOST_NUMPY, source=[m+OBJ_SUFFIX for m in mods])
+if os.name == 'nt':
+    lib = env.StaticLibrary(LIB_BOOST_NUMPY, source=[m+OBJ_SUFFIX for m in mods])
+else:
+    lib = env.SharedLibrary(LIB_BOOST_NUMPY, source=[m+OBJ_SUFFIX for m in mods])
 
 Return("lib")


### PR DESCRIPTION
Hi Devteam,

I just added a few lines to the library SCons file, so that a static library is built for Windows.

Building a shared library would require __declspec(dllexport) and the respective dllimport declarations for all exported methods. This currently requires more time than I can invest, so I decided to build a static version. I'd be happy if you include it, so that the library can be used on Windows as well!

Best,
Christoph
