### PR TITLE
Fix boost_python3 library discovery on configure

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,13 +45,30 @@ find_package(NumPy REQUIRED)
 # set(Boost_USE_STATIC_RUNTIME ON)
 set(CMAKE_MACOSX_RPATH 1)
 
+# Add some logic to work around distribution-specific naming of boost
+# python libraries. This is a particular problem when trying to use a 
+# python version on a system that is not the default.
+STRING(REPLACE "." ";" BOOST_PYTHON_VERSION ${PYTHON_VERSION_STRING})
+LIST(GET BOOST_PYTHON_VERSION 0 BOOST_PYTHON_VERSION_MAJOR)
+LIST(GET BOOST_PYTHON_VERSION 1 BOOST_PYTHON_VERSION_MINOR)
+
+# Now set the different variants of the library name to check for
+SET(_BOOST_PYTHON_LIB_NAMES_TO_TRY python${BOOST_PYTHON_VERSION_MAJOR}${BOOST_PYTHON_VERSION_MINOR} python${BOOST_PYTHON_VERSION_MAJOR} python-py${BOOST_PYTHON_VERSION_MAJOR}${BOOST_PYTHON_VERSION_MINOR} python-py${BOOST_PYTHON_VERSION_MAJOR})
+
 if(${PYTHON_VERSION_STRING} GREATER 3.0)
   message(STATUS "Using Python3")
-  find_package(Boost COMPONENTS python3 REQUIRED)
 else()
   message(STATUS "Using Python2")
-  find_package(Boost COMPONENTS python REQUIRED)
+  list(APPEND _BOOST_PYTHON_LIB_NAMES_TO_TRY "python")
 endif()
+
+FOREACH(BOOST_PYTHON_LIB_NAME ${_BOOST_PYTHON_LIB_NAMES_TO_TRY})
+    find_package(Boost QUIET COMPONENTS ${BOOST_PYTHON_LIB_NAME})
+    STRING(TOUPPER ${BOOST_PYTHON_LIB_NAME} BOOST_PYTHON_LIB_NAME_UPPER)
+    IF (Boost_${BOOST_PYTHON_LIB_NAME_UPPER}_FOUND)
+        break()
+    ENDIF()
+ENDFOREACH()
 
 message( STATUS "Boost Paths:")
 message( STATUS "Include  : " ${Boost_INCLUDE_DIRS})

--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
-# Boost.NumPy [![Build Status](https://travis-ci.org/ndarray/Boost.NumPy.svg?branch=master)](https://travis-ci.org/ndarray/Boost.NumPy)
+# Boost.NumPy 
+
+This fork of Boost.NumPy has been updated to fix issues with boost\_python3 library
+discovery on distributions that use non-standard naming for the library. In particular,
+issues were experienced on Ubuntu Linux and this issue is resolved in this fork.
 
 > # THIS PACKAGE IS NOW DEPRECATED IN FAVOR OF NUMPY SUPPORT INCLUDED DIRECTLY IN BOOST.PYTHON.
 >


### PR DESCRIPTION
This update fixes the CMake configuration resolving issues that were encountered with discovering the boost_python3 library on Ubuntu 16.04. Where the library has non-standard naming, it isn't picked up by the CMake configuration process for Boost.NumPy.
